### PR TITLE
Use Ember.String.htmlsafe if possible

### DIFF
--- a/addon/computed-style.js
+++ b/addon/computed-style.js
@@ -1,8 +1,7 @@
 import Ember from 'ember';
 
 const { isEmpty, get, computed } = Ember;
-const { dasherize } = Ember.String;
-const { SafeString } = Ember.Handlebars;
+const { dasherize, htmlSafe } = Ember.String;
 
 /**
  * Lifted from Ember Metal Computed Macros
@@ -123,5 +122,12 @@ export var computedStyle = generateComputedWithProperties(function computedStyle
     styleString+=';';
   }
 
-  return new SafeString(styleString);
+  if (htmlSafe) {
+    return htmlSafe(styleString);
+  } else {
+    // backwards compatibility for method deprecated since
+    // ember v2.8.0
+    return new Ember.Handlebars.SafeString(styleString);
+  }
+
 });

--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "ember-qunit": "0.4.16",
     "ember-qunit-notifications": "0.1.0",
     "ember-resolver": "~0.1.20",
-    "jquery": "^1.11.3",
+    "jquery": "1.11.3",
     "loader.js": "ember-cli/loader.js#3.4.0",
     "qunit": "~1.20.0"
   }


### PR DESCRIPTION
This will avoid deprecation warnings in Ember v2.8.0.

I also had to lock in the jquery version to get the tests to run [(see this)](https://github.com/ember-cli/ember-cli/issues/5350#issuecomment-173495736).

Passes `ember try:testall` and `ember t`
